### PR TITLE
Drop flake8, isort, black in favor of ruff

### DIFF
--- a/{{"cookiecutter."|last~"devcontainer"}}/dev-conda-environment.yaml
+++ b/{{"cookiecutter."|last~"devcontainer"}}/dev-conda-environment.yaml
@@ -6,9 +6,7 @@ dependencies:
 - git  # Also installed from Ubuntu, but this is newer.
 - xonsh
 - pre-commit
-- black
-- isort
-- flake8
+- ruff
 - pytest
 - dasel
 - mamba
@@ -19,11 +17,6 @@ dependencies:
 - line_profiler
 - cookiecutter
 - cruft
-- flake8-use-fstring
-- flake8-blind-except
-- flake8-builtins
-- flake8-use-pathlib
-- flake8-noqa
 
 # # In case you want to install packages from PyPI which aren't on Conda-Forge,
 # # uncomment this block and add them as follows:

--- a/{{"cookiecutter."|last~"devcontainer"}}/devcontainer.json
+++ b/{{"cookiecutter."|last~"devcontainer"}}/devcontainer.json
@@ -31,8 +31,7 @@
 			"extensions": [
 				"ms-python.python",
 				"ms-python.vscode-pylance",
-				"ms-python.flake8",
-				"ms-python.isort",
+				"charliermarsh.ruff",
 				"ms-toolsai.jupyter",
 				"ms-azuretools.vscode-docker",
 				"ms-vsliveshare.vsliveshare",
@@ -61,21 +60,9 @@
 					".devcontainer/cache/*/[!\\.]*": true,
 				},
 
-				// For linting (code format checking), disable pylint and enable
-				// pydocstyle for docstrings and flake8 for code.
-				"python.linting.pylintEnabled": false,
-				"python.linting.pydocstyleEnabled": false,
-				"python.linting.flake8Enabled": true,
-				"python.linting.flake8Args": [
-					"--max-line-length=88",
-					// Let black handle formatting: <https://stackoverflow.com/q/59241007>
-					// Also exclude isort stuff: <https://stackoverflow.com/a/69396215>
-					// But don't exclude E5 for line length
-					"--extend-ignore=E101,E111,E114,E115,E116,E117,E12,E13,E2,E3,E401,E70,W1,W2,W3,W5,E4,W4",
-				],
-
-				// Turn on "black" for automatic code formatting
-				"python.formatting.provider": "black",
+				"python.editor.defaultFormatter": "charliermarsh.ruff",
+				"ruff.path": ["/opt/conda/bin/ruff"],
+				"ruff.interpreter": ["/opt/conda/bin/python"],
 
 				// Ruler for "black"-formatted line widths
 				"editor.rulers": [88],
@@ -92,12 +79,6 @@
 				// Use Pylance
 				"python.languageServer": "Pylance",
 				"python.analysis.typeCheckingMode": "basic",
-
-				// Use isort for imports
-				"python.sortImports.path": "/opt/conda/bin/isort",
-				"python.sortImports.args": [
-					"--settings-path=${workspaceFolder}/pyproject.toml"
-				], // <https://github.com/microsoft/vscode-isort/issues/53#issuecomment-1310754796>
 
 				// Interpret lines beginning with "# !%" as ipython magic commands
 				"jupyter.interactiveWindow.textEditor.magicCommandsAsComments": true,


### PR DESCRIPTION
Note: to perform a comprehensive format I added the following to my keybindings.json:

```json
    {
        "key": "ctrl+shift+i",
        "command": "runCommands",
        "args": {
            "commands": ["editor.action.fixAll", "editor.action.formatDocument"],
        }
    },
```