### PR TITLE
Revert "Update base image to git-b34ef03"

### DIFF
--- a/{{"cookiecutter."|last~"devcontainer"}}/dev.Dockerfile
+++ b/{{"cookiecutter."|last~"devcontainer"}}/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/mamba-org/micromamba-devcontainer:git-b34ef03
+FROM ghcr.io/mamba-org/micromamba-devcontainer:git-63599dc
 
 # Ensure that all users have read-write access to all files created in the subsequent commands.
 ARG DOCKERFILE_UMASK=0000


### PR DESCRIPTION
This reverts commit 212aebf365cfe496c229caef18484c39a3a3b975.

This resets the tag back to 63599dc, because this tag probably includes cuda. (See https://github.com/mamba-org/micromamba-devcontainer/issues/29#issuecomment-1851038784)